### PR TITLE
Update rational.hpp

### DIFF
--- a/include/boost/rational.hpp
+++ b/include/boost/rational.hpp
@@ -172,9 +172,9 @@ public:
 
     // Access to representation
     BOOST_CONSTEXPR
-    IntType numerator() const { return num; }
+    const IntType& numerator() const { return num; }
     BOOST_CONSTEXPR
-    IntType denominator() const { return den; }
+    const IntType& denominator() const { return den; }
 
     // Arithmetic assignment operators
     rational& operator+= (const rational& r);


### PR DESCRIPTION
Access to the numerator and denominator is unnecessarily inefficient when using rational with multiprecision types (ie where copying is relatively expensive), this change returns const-references to numerator and denominator.  In all other respects existing code should be uneffected by this change.
