### PR TITLE
Add constexpr usage checks

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -3,9 +3,12 @@
 #~ (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 import testing ;
+import ../../config/checks/config : requires ;
+
 
 test-suite rational
     :   [ run rational_example.cpp ]
         [ run rational_test.cpp
             /boost/test//boost_unit_test_framework/<link>static ]
+        [ run constexpr_test.cpp : : : [ requires cxx11_constexpr ] ]
     ;

--- a/test/constexpr_test.cpp
+++ b/test/constexpr_test.cpp
@@ -1,0 +1,26 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2015 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/rational.hpp>
+
+
+int main()
+{
+#ifndef BOOST_NO_CONSTEXPR
+   constexpr boost::rational<int> i1;
+   constexpr boost::rational<int> i2(3);
+   constexpr boost::rational<short> i3(i2);
+
+   static_assert(i1.numerator() == 0, "constexpr test");
+   static_assert(i1.denominator() == 1, "constexpr test");
+   static_assert(i2.numerator() == 3, "constexpr test");
+   static_assert(i2.denominator() == 1, "constexpr test");
+   static_assert(i3.numerator() == 3, "constexpr test");
+   static_assert(i3.denominator() == 1, "constexpr test");
+   static_assert(!i1, "constexpr test");
+   static_assert(i2, "constexpr test");
+#endif
+   return 0;
+}

--- a/test/rational_test.cpp
+++ b/test/rational_test.cpp
@@ -958,21 +958,6 @@ BOOST_AUTO_TEST_CASE( rational_cast_test )
 
     BOOST_CHECK_EQUAL( boost::rational_cast<MyOverflowingUnsigned>(threehalves),
      MyOverflowingUnsigned(1u) );
-
-#ifndef BOOST_NO_CONSTEXPR
-    constexpr boost::rational<int> i1;
-    constexpr boost::rational<int> i2(3);
-    constexpr boost::rational<short> i3(i2);
-
-    static_assert(i1.numerator() == 0, "constexpr test");
-    static_assert(i1.denominator() == 1, "constexpr test");
-    static_assert(i2.numerator() == 3, "constexpr test");
-    static_assert(i2.denominator() == 1, "constexpr test");
-    static_assert(i3.numerator() == 3, "constexpr test");
-    static_assert(i3.denominator() == 1, "constexpr test");
-    static_assert(!i1, "constexpr test");
-    static_assert(i2, "constexpr test");
-#endif
 }
 
 #ifndef BOOST_NO_MEMBER_TEMPLATES

--- a/test/rational_test.cpp
+++ b/test/rational_test.cpp
@@ -958,6 +958,21 @@ BOOST_AUTO_TEST_CASE( rational_cast_test )
 
     BOOST_CHECK_EQUAL( boost::rational_cast<MyOverflowingUnsigned>(threehalves),
      MyOverflowingUnsigned(1u) );
+
+#ifndef BOOST_NO_CONSTEXPR
+    constexpr boost::rational<int> i1;
+    constexpr boost::rational<int> i2(3);
+    constexpr boost::rational<short> i3(i2);
+
+    static_assert(i1.numerator() == 0, "constexpr test");
+    static_assert(i1.denominator() == 1, "constexpr test");
+    static_assert(i2.numerator() == 3, "constexpr test");
+    static_assert(i2.denominator() == 1, "constexpr test");
+    static_assert(i3.numerator() == 3, "constexpr test");
+    static_assert(i3.denominator() == 1, "constexpr test");
+    static_assert(!i1, "constexpr test");
+    static_assert(i2, "constexpr test");
+#endif
 }
 
 #ifndef BOOST_NO_MEMBER_TEMPLATES


### PR DESCRIPTION
Add constexpr usage checks - without these we can't be sure that other changes don't break something.
