### PR TITLE
Boost throw exception

### DIFF
--- a/include/boost/rational.hpp
+++ b/include/boost/rational.hpp
@@ -82,6 +82,7 @@
 #include <boost/math/common_factor_rt.hpp>  // for boost::math::gcd, lcm
 #include <limits>                // for std::numeric_limits
 #include <boost/static_assert.hpp>  // for BOOST_STATIC_ASSERT
+#include <boost/throw_exception.hpp>
 
 // Control whether depreciated GCD and LCM functions are included (default: yes)
 #ifndef BOOST_CONTROL_RATIONAL_HAS_GCD
@@ -154,12 +155,13 @@ public:
 
 #ifndef BOOST_NO_MEMBER_TEMPLATES
     template < typename NewType >
-    BOOST_CONSTEXPR explicit
+    explicit
     rational( rational<NewType> const &r )
-        : num( r.numerator() ), den( is_normalized(int_type( r.numerator() ),
-          int_type( r.denominator() )) ? r.denominator() :
-          throw bad_rational("bad rational: denormalized conversion") )
-    {}
+        : num( r.numerator() ), den( r.denominator() )          
+    {
+       if(!is_normalized(num, den))
+          BOOST_THROW_EXCEPTION(bad_rational("bad rational: denormalized conversion"));
+    }
 #endif
 
     // Default copy constructor and assignment are fine
@@ -356,7 +358,7 @@ rational<IntType>& rational<IntType>::operator/= (const rational<IntType>& r)
 
     // Trap division by zero
     if (r_num == zero)
-        throw bad_rational();
+        BOOST_THROW_EXCEPTION(bad_rational());
     if (num == zero)
         return *this;
 
@@ -393,7 +395,7 @@ rational<IntType>::operator/= (param_type i)
     // Avoid repeated construction
     IntType const zero(0);
 
-    if (i == zero) throw bad_rational();
+    if(i == zero) BOOST_THROW_EXCEPTION(bad_rational());
     if (num == zero) return *this;
 
     // Avoid overflow and preserve normalization
@@ -548,7 +550,7 @@ void rational<IntType>::normalize()
     IntType zero(0);
 
     if (den == zero)
-        throw bad_rational();
+       BOOST_THROW_EXCEPTION(bad_rational());
 
     // Handle the case of zero separately, to avoid division by zero
     if (num == zero) {
@@ -572,7 +574,7 @@ void rational<IntType>::normalize()
     // member function is only called during the constructor, so we never have
     // to worry about zombie objects.)
     if (den < zero)
-        throw bad_rational( "bad rational: non-zero singular denominator" );
+       BOOST_THROW_EXCEPTION(bad_rational("bad rational: non-zero singular denominator"));
 
     BOOST_ASSERT( this->test_invariant() );
 }

--- a/include/boost/rational.hpp
+++ b/include/boost/rational.hpp
@@ -155,13 +155,11 @@ public:
 
 #ifndef BOOST_NO_MEMBER_TEMPLATES
     template < typename NewType >
-    explicit
-    rational( rational<NewType> const &r )
-        : num( r.numerator() ), den( r.denominator() )          
-    {
-       if(!is_normalized(num, den))
-          BOOST_THROW_EXCEPTION(bad_rational("bad rational: denormalized conversion"));
-    }
+    BOOST_CONSTEXPR explicit
+       rational(rational<NewType> const &r)
+       : num(r.numerator()), den(is_normalized(int_type(r.numerator()),
+       int_type(r.denominator())) ? r.denominator() :
+       (BOOST_THROW_EXCEPTION(bad_rational("bad rational: denormalized conversion")), 0)){}
 #endif
 
     // Default copy constructor and assignment are fine

--- a/test/rational_test.cpp
+++ b/test/rational_test.cpp
@@ -973,6 +973,10 @@ BOOST_AUTO_TEST_CASE( rational_cast_test )
     static_assert(!i1, "constexpr test");
     static_assert(i2, "constexpr test");
 #endif
+    //
+    // Converting constructor should throw if a bad rational number results:
+    //
+    BOOST_CHECK_THROW(boost::rational<short>(boost::rational<long>(1, 1 << sizeof(short) * CHAR_BIT)), boost::bad_rational);
 }
 
 #ifndef BOOST_NO_MEMBER_TEMPLATES


### PR DESCRIPTION
This patch changes the code to use BOOST_THROW_EXCEPTION throughout - this leads to a number of advantages including enhanced Boost.Exception support and very nearly support for building with exceptions disabled: currently everything except the iostreams operators work without exceptions.

This patch also includes everything from https://github.com/boostorg/rational/pull/2, since it requires those enhanced tests.
