### PR TITLE
No float convert

### DIFF
--- a/include/boost/rational.hpp
+++ b/include/boost/rational.hpp
@@ -79,7 +79,7 @@
 #include <boost/call_traits.hpp> // for boost::call_traits
 #include <boost/detail/workaround.hpp> // for BOOST_WORKAROUND
 #include <boost/assert.hpp>      // for BOOST_ASSERT
-#include <boost/math/common_factor_rt.hpp>  // for boost::math::gcd, lcm
+#include <boost/integer/common_factor_rt.hpp> // for boost::integer::gcd, lcm
 #include <limits>                // for std::numeric_limits
 #include <boost/static_assert.hpp>  // for BOOST_STATIC_ASSERT
 
@@ -95,14 +95,14 @@ template <typename IntType>
 IntType gcd(IntType n, IntType m)
 {
     // Defer to the version in Boost.Math
-    return math::gcd( n, m );
+    return integer::gcd( n, m );
 }
 
 template <typename IntType>
 IntType lcm(IntType n, IntType m)
 {
     // Defer to the version in Boost.Math
-    return math::lcm( n, m );
+    return integer::lcm( n, m );
 }
 #endif  // BOOST_CONTROL_RATIONAL_HAS_GCD
 
@@ -300,10 +300,10 @@ rational<IntType>& rational<IntType>::operator+= (const rational<IntType>& r)
     IntType r_num = r.num;
     IntType r_den = r.den;
 
-    IntType g = math::gcd(den, r_den);
+    IntType g = integer::gcd(den, r_den);
     den /= g;  // = b1 from the calculations above
     num = num * (r_den / g) + r_num * den;
-    g = math::gcd(num, g);
+    g = integer::gcd(num, g);
     num /= g;
     den *= r_den/g;
 
@@ -319,10 +319,10 @@ rational<IntType>& rational<IntType>::operator-= (const rational<IntType>& r)
 
     // This calculation avoids overflow, and minimises the number of expensive
     // calculations. It corresponds exactly to the += case above
-    IntType g = math::gcd(den, r_den);
+    IntType g = integer::gcd(den, r_den);
     den /= g;
     num = num * (r_den / g) - r_num * den;
-    g = math::gcd(num, g);
+    g = integer::gcd(num, g);
     num /= g;
     den *= r_den/g;
 
@@ -337,8 +337,8 @@ rational<IntType>& rational<IntType>::operator*= (const rational<IntType>& r)
     IntType r_den = r.den;
 
     // Avoid overflow and preserve normalization
-    IntType gcd1 = math::gcd(num, r_den);
-    IntType gcd2 = math::gcd(r_num, den);
+    IntType gcd1 = integer::gcd(num, r_den);
+    IntType gcd2 = integer::gcd(r_num, den);
     num = (num/gcd1) * (r_num/gcd2);
     den = (den/gcd2) * (r_den/gcd1);
     return *this;
@@ -361,8 +361,8 @@ rational<IntType>& rational<IntType>::operator/= (const rational<IntType>& r)
         return *this;
 
     // Avoid overflow and preserve normalization
-    IntType gcd1 = math::gcd(num, r_num);
-    IntType gcd2 = math::gcd(r_den, den);
+    IntType gcd1 = integer::gcd(num, r_num);
+    IntType gcd2 = integer::gcd(r_den, den);
     num = (num/gcd1) * (r_den/gcd2);
     den = (den/gcd2) * (r_num/gcd1);
 
@@ -379,7 +379,7 @@ inline rational<IntType>&
 rational<IntType>::operator*= (param_type i)
 {
     // Avoid overflow and preserve normalization
-    IntType gcd = math::gcd(i, den);
+    IntType gcd = integer::gcd(i, den);
     num *= i / gcd;
     den /= gcd;
 
@@ -397,7 +397,7 @@ rational<IntType>::operator/= (param_type i)
     if (num == zero) return *this;
 
     // Avoid overflow and preserve normalization
-    IntType const gcd = math::gcd(num, i);
+    IntType const gcd = integer::gcd(num, i);
     num /= gcd;
     den *= i / gcd;
 
@@ -536,7 +536,7 @@ inline bool rational<IntType>::operator== (param_type i) const
 template <typename IntType>
 inline bool rational<IntType>::test_invariant() const
 {
-    return ( this->den > int_type(0) ) && ( math::gcd(this->num, this->den) ==
+    return ( this->den > int_type(0) ) && ( integer::gcd(this->num, this->den) ==
      int_type(1) );
 }
 
@@ -556,7 +556,7 @@ void rational<IntType>::normalize()
         return;
     }
 
-    IntType g = math::gcd(num, den);
+    IntType g = integer::gcd(num, den);
 
     num /= g;
     den /= g;

--- a/include/boost/rational.hpp
+++ b/include/boost/rational.hpp
@@ -119,7 +119,7 @@ namespace rational_detail{
       BOOST_STATIC_CONSTANT(bool, value = ((std::numeric_limits<FromInt>::is_specialized && std::numeric_limits<FromInt>::is_integer
          && (std::numeric_limits<FromInt>::digits <= std::numeric_limits<ToInt>::digits)
          && (std::numeric_limits<FromInt>::radix == std::numeric_limits<ToInt>::radix)
-         && (std::numeric_limits<FromInt>::is_signed == std::numeric_limits<ToInt>::is_signed)
+         && ((std::numeric_limits<FromInt>::is_signed == false) || (std::numeric_limits<ToInt>::is_signed == true))
          && is_convertible<FromInt, ToInt>::value)
          || is_same<FromInt, ToInt>::value)
          || (is_class<ToInt>::value && is_class<FromInt>::value && is_convertible<FromInt, ToInt>::value));
@@ -199,8 +199,7 @@ public:
     template <class T>
     rational(const T& n, typename enable_if_c<
        std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::is_integer
-       && ((std::numeric_limits<T>::digits > std::numeric_limits<IntType>::digits)
-       || (std::numeric_limits<T>::is_signed != std::numeric_limits<IntType>::is_signed))
+       && !rational_detail::is_compatible_integer<T, IntType>::value
        && (std::numeric_limits<T>::radix == std::numeric_limits<IntType>::radix)
        && is_convertible<T, IntType>::value
     >::type const* = 0)
@@ -210,8 +209,7 @@ public:
     template <class T>
     rational(const T& n, const T& d, typename enable_if_c<
        std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::is_integer
-       && ((std::numeric_limits<T>::digits > std::numeric_limits<IntType>::digits)
-       || (std::numeric_limits<T>::is_signed != std::numeric_limits<IntType>::is_signed))
+       && !rational_detail::is_compatible_integer<T, IntType>::value
        && (std::numeric_limits<T>::radix == std::numeric_limits<IntType>::radix)
        && is_convertible<T, IntType>::value
     >::type const* = 0)
@@ -221,8 +219,7 @@ public:
     template <class T>
     typename enable_if_c<
        std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::is_integer
-       && ((std::numeric_limits<T>::digits > std::numeric_limits<IntType>::digits)
-       || (std::numeric_limits<T>::is_signed != std::numeric_limits<IntType>::is_signed))
+       && !rational_detail::is_compatible_integer<T, IntType>::value
        && (std::numeric_limits<T>::radix == std::numeric_limits<IntType>::radix)
        && is_convertible<T, IntType>::value,
        rational &
@@ -231,8 +228,7 @@ public:
     template <class T>
     typename enable_if_c<
        std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::is_integer
-       && ((std::numeric_limits<T>::digits > std::numeric_limits<IntType>::digits)
-       || (std::numeric_limits<T>::is_signed != std::numeric_limits<IntType>::is_signed))
+       && !rational_detail::is_compatible_integer<T, IntType>::value
        && (std::numeric_limits<T>::radix == std::numeric_limits<IntType>::radix)
        && is_convertible<T, IntType>::value,
        rational &

--- a/include/boost/rational.hpp
+++ b/include/boost/rational.hpp
@@ -441,7 +441,7 @@ bool rational<IntType>::operator< (const rational<IntType>& r) const
     while ( rs.r < zero )  { rs.r += rs.d; --rs.q; }
 
     // Loop through and compare each variable's continued-fraction components
-    while ( true )
+    for ( ;; )
     {
         // The quotients of the current cycle are the continued-fraction
         // components.  Comparing two c.f. is comparing their sequences,

--- a/include/boost/rational.hpp
+++ b/include/boost/rational.hpp
@@ -407,7 +407,7 @@ private:
        return val < safe_max_t;
     }
     template <class T>
-    typename boost::enable_if_c<(std::numeric_limits<T>::digits > std::numeric_limits<IntType>::digits) && (std::numeric_limits<T>::is_signed == true), bool>::type is_safe_narrowing_conversion(const T& val)
+    typename boost::enable_if_c<(std::numeric_limits<T>::digits > std::numeric_limits<IntType>::digits) && (std::numeric_limits<T>::is_signed == true) && (std::numeric_limits<IntType>::is_signed == true), bool>::type is_safe_narrowing_conversion(const T& val)
     {
        // Note that this check assumes IntType has a 2's complement representation,
        // we don't want to try to convert a std::numeric_limits<IntType>::min() to
@@ -417,12 +417,18 @@ private:
        return (val < safe_max_t) && (val >= -safe_max_t);
     }
     template <class T>
-    typename boost::enable_if_c<(std::numeric_limits<T>::is_signed == true) && (std::numeric_limits<IntType>::is_signed == false), bool>::type is_safe_narrowing_conversion(const T& val)
+    typename boost::enable_if_c<(std::numeric_limits<T>::digits > std::numeric_limits<IntType>::digits) && (std::numeric_limits<T>::is_signed == true) && (std::numeric_limits<IntType>::is_signed == false), bool>::type is_safe_narrowing_conversion(const T& val)
+    {
+       static const T safe_max_t = T(1) << std::numeric_limits<IntType>::digits;
+       return (val < safe_max_t) && (val >= 0);
+    }
+    template <class T>
+    typename boost::enable_if_c<(std::numeric_limits<T>::digits <= std::numeric_limits<IntType>::digits) && (std::numeric_limits<T>::is_signed == true) && (std::numeric_limits<IntType>::is_signed == false), bool>::type is_safe_narrowing_conversion(const T& val)
     {
        return val >= 0;
     }
     template <class T>
-    typename boost::enable_if_c<(std::numeric_limits<T>::is_signed == false) && (std::numeric_limits<IntType>::is_signed == true), bool>::type is_safe_narrowing_conversion(const T&)
+    typename boost::enable_if_c<(std::numeric_limits<T>::digits <= std::numeric_limits<IntType>::digits) && (std::numeric_limits<T>::is_signed == false) && (std::numeric_limits<IntType>::is_signed == true), bool>::type is_safe_narrowing_conversion(const T&)
     {
        return true;
     }

--- a/include/boost/rational.hpp
+++ b/include/boost/rational.hpp
@@ -885,26 +885,25 @@ std::istream& operator>> (std::istream& is, rational<IntType>& r)
 template <typename IntType>
 std::ostream& operator<< (std::ostream& os, const rational<IntType>& r)
 {
-    using namespace std;
-
     // The slash directly precedes the denominator, which has no prefixes.
-    ostringstream  ss;
+    std::ostringstream  ss;
 
     ss.copyfmt( os );
     ss.tie( NULL );
-    ss.exceptions( ios::goodbit );
+    ss.exceptions( std::ios::goodbit );
     ss.width( 0 );
-    ss << noshowpos << noshowbase << '/' << r.denominator();
+    ss << std::noshowpos << std::noshowbase << '/' << r.denominator();
 
     // The numerator holds the showpos, internal, and showbase flags.
-    string const   tail = ss.str();
-    streamsize const  w = os.width() - static_cast<streamsize>( tail.size() );
+    std::string const   tail = ss.str();
+    std::streamsize const  w =
+        os.width() - static_cast<std::streamsize>( tail.size() );
 
     ss.clear();
     ss.str( "" );
     ss.flags( os.flags() );
-    ss << setw( w < 0 || (os.flags() & ios::adjustfield) != ios::internal ? 0 :
-     w ) << r.numerator();
+    ss << std::setw( w < 0 || (os.flags() & std::ios::adjustfield) !=
+                     std::ios::internal ? 0 : w ) << r.numerator();
     return os << ss.str() + tail;
 }
 #endif  // BOOST_NO_IOSTREAM
@@ -926,7 +925,38 @@ inline rational<IntType> abs(const rational<IntType>& r)
     return r.numerator() >= IntType(0)? r: -r;
 }
 
+namespace integer {
+
+template <typename IntType>
+struct gcd_evaluator< rational<IntType> >
+{
+    typedef rational<IntType> result_type,
+                              first_argument_type, second_argument_type;
+    result_type operator() (  first_argument_type const &a
+                           , second_argument_type const &b
+                           ) const
+    {
+        return result_type(integer::gcd(a.numerator(), b.numerator()),
+                           integer::lcm(a.denominator(), b.denominator()));
+    }
+};
+
+template <typename IntType>
+struct lcm_evaluator< rational<IntType> >
+{
+    typedef rational<IntType> result_type,
+                              first_argument_type, second_argument_type;
+    result_type operator() (  first_argument_type const &a
+                           , second_argument_type const &b
+                           ) const
+    {
+        return result_type(integer::lcm(a.numerator(), b.numerator()),
+                           integer::gcd(a.denominator(), b.denominator()));
+    }
+};
+
+} // namespace integer
+
 } // namespace boost
 
 #endif  // BOOST_RATIONAL_HPP
-

--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -1,0 +1,14 @@
+{
+    "key": "rational",
+    "name": "Rational",
+    "authors": [
+        "Paul Moore"
+    ],
+    "description": "A rational number class.",
+    "category": [
+        "Math"
+    ],
+    "maintainers": [
+        "Jonathan Turkanis <turkanis -at- coderage.com>"
+    ]
+}

--- a/rational.html
+++ b/rational.html
@@ -269,7 +269,7 @@ href="#Integer%20Type%20Requirements">any type that can be used</a> with the
 </table>
 
 <p>These function templates now forward calls to their equivalents in the <a
-href="../math/">Boost.Math library</a>.  Their presence can be controlled at
+href="../integer/">Boost.Integer library</a>.  Their presence can be controlled at
 compile time with the <code>BOOST_CONTROL_RATIONAL_HAS_GCD</code> preprocessor
 constant.
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -11,4 +11,15 @@ test-suite rational
         [ run rational_test.cpp
             /boost/test//boost_unit_test_framework/<link>static ]
         [ run constexpr_test.cpp : : : [ requires cxx11_constexpr ] ]
+        [ compile-fail expected_fail_01.cpp ]
+        [ compile-fail expected_fail_02.cpp ]
+        [ compile-fail expected_fail_03.cpp ]
+        [ compile-fail expected_fail_04.cpp ]
+        [ compile-fail expected_fail_05.cpp ]
+        [ compile-fail expected_fail_06.cpp ]
+        [ compile-fail expected_fail_07.cpp ]
+        [ compile-fail expected_fail_08.cpp ]
+        [ compile-fail expected_fail_09.cpp ]
+        [ compile-fail expected_fail_10.cpp ]
+        [ compile-fail expected_fail_11.cpp ]
     ;

--- a/test/constexpr_test.cpp
+++ b/test/constexpr_test.cpp
@@ -8,7 +8,7 @@
 
 int main()
 {
-#ifndef BOOST_NO_CONSTEXPR
+#ifndef BOOST_NO_CXX11_CONSTEXPR
    constexpr boost::rational<int> i1;
    constexpr boost::rational<int> i2(3);
    constexpr boost::rational<long long> i3(i2);

--- a/test/constexpr_test.cpp
+++ b/test/constexpr_test.cpp
@@ -11,7 +11,10 @@ int main()
 #ifndef BOOST_NO_CONSTEXPR
    constexpr boost::rational<int> i1;
    constexpr boost::rational<int> i2(3);
-   constexpr boost::rational<short> i3(i2);
+   constexpr boost::rational<long long> i3(i2);
+   constexpr boost::rational<short> i4(i2);
+   constexpr boost::rational<long long> i5(23u); // converting constructor
+   constexpr boost::rational<short> i6(23u); // converting constructor
 
    static_assert(i1.numerator() == 0, "constexpr test");
    static_assert(i1.denominator() == 1, "constexpr test");

--- a/test/constexpr_test.cpp
+++ b/test/constexpr_test.cpp
@@ -14,7 +14,7 @@ int main()
    constexpr boost::rational<long long> i3(i2);
    constexpr boost::rational<short> i4(i2);
    constexpr boost::rational<long long> i5(23u); // converting constructor
-   constexpr boost::rational<short> i6(23u); // converting constructor
+   // constexpr boost::rational<short> i6(23u); // Not supported, needs an explicit typecast in constructor.
 
    static_assert(i1.numerator() == 0, "constexpr test");
    static_assert(i1.denominator() == 1, "constexpr test");

--- a/test/expected_fail_01.cpp
+++ b/test/expected_fail_01.cpp
@@ -1,0 +1,11 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2015 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/rational.hpp>
+
+int main()
+{
+   boost::rational<int> rat(3.14);
+}

--- a/test/expected_fail_02.cpp
+++ b/test/expected_fail_02.cpp
@@ -1,0 +1,12 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2015 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/rational.hpp>
+
+int main()
+{
+   boost::rational<int> rat(2);
+   rat = 0.5;
+}

--- a/test/expected_fail_03.cpp
+++ b/test/expected_fail_03.cpp
@@ -1,0 +1,12 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2015 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/rational.hpp>
+
+int main()
+{
+   boost::rational<int> rat(2);
+   return rat == 0.5;
+}

--- a/test/expected_fail_04.cpp
+++ b/test/expected_fail_04.cpp
@@ -1,0 +1,12 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2015 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/rational.hpp>
+
+int main()
+{
+   boost::rational<int> rat(2);
+   rat += 0.5;
+}

--- a/test/expected_fail_05.cpp
+++ b/test/expected_fail_05.cpp
@@ -1,0 +1,12 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2015 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/rational.hpp>
+
+int main()
+{
+   boost::rational<int> rat(2);
+   rat -= 0.5;
+}

--- a/test/expected_fail_06.cpp
+++ b/test/expected_fail_06.cpp
@@ -1,0 +1,12 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2015 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/rational.hpp>
+
+int main()
+{
+   boost::rational<int> rat(2);
+   rat *= 0.5;
+}

--- a/test/expected_fail_07.cpp
+++ b/test/expected_fail_07.cpp
@@ -1,0 +1,12 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2015 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/rational.hpp>
+
+int main()
+{
+   boost::rational<int> rat(2);
+   rat /= 0.5;
+}

--- a/test/expected_fail_08.cpp
+++ b/test/expected_fail_08.cpp
@@ -1,0 +1,12 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2015 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/rational.hpp>
+
+int main()
+{
+   boost::rational<int> rat(2);
+   rat = rat + 0.5;
+}

--- a/test/expected_fail_09.cpp
+++ b/test/expected_fail_09.cpp
@@ -1,0 +1,12 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2015 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/rational.hpp>
+
+int main()
+{
+   boost::rational<int> rat(2);
+   rat = rat - 0.5;
+}

--- a/test/expected_fail_10.cpp
+++ b/test/expected_fail_10.cpp
@@ -1,0 +1,12 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2015 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/rational.hpp>
+
+int main()
+{
+   boost::rational<int> rat(2);
+   rat = rat / 0.5;
+}

--- a/test/expected_fail_11.cpp
+++ b/test/expected_fail_11.cpp
@@ -1,0 +1,12 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2015 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/rational.hpp>
+
+int main()
+{
+   boost::rational<int> rat(2);
+   rat = rat * 0.5;
+}

--- a/test/rational_test.cpp
+++ b/test/rational_test.cpp
@@ -42,7 +42,7 @@
 #include <boost/mpl/list.hpp>
 #include <boost/operators.hpp>
 #include <boost/preprocessor/stringize.hpp>
-#include <boost/math/common_factor_rt.hpp>
+#include <boost/integer/common_factor_rt.hpp>
 
 #include <boost/rational.hpp>
 
@@ -1033,8 +1033,8 @@ BOOST_AUTO_TEST_CASE( bug_798357_test )
     unsigned const  n2 = d1, d2 = UINT_MAX;
     boost::rational<MyOverflowingUnsigned> const  r1( n1, d1 ), r2( n2, d2 );
 
-    BOOST_REQUIRE_EQUAL( boost::math::gcd(n1, d1), 1u );
-    BOOST_REQUIRE_EQUAL( boost::math::gcd(n2, d2), 1u );
+    BOOST_REQUIRE_EQUAL( boost::integer::gcd(n1, d1), 1u );
+    BOOST_REQUIRE_EQUAL( boost::integer::gcd(n2, d2), 1u );
     BOOST_REQUIRE( n1 > UINT_MAX / d2 );
     BOOST_REQUIRE( n2 > UINT_MAX / d1 );
     BOOST_CHECK( r1 < r2 );
@@ -1063,7 +1063,7 @@ BOOST_AUTO_TEST_CASE( patch_1438626_test )
     // If a GCD routine takes the absolute value of an argument only before
     // processing, it won't realize that -INT_MIN -> INT_MIN (i.e. no change
     // from negation) and will propagate a negative sign to its result.
-    BOOST_REQUIRE_EQUAL( boost::math::gcd(INT_MIN, 6), 2 );
+    BOOST_REQUIRE_EQUAL( boost::integer::gcd(INT_MIN, 6), 2 );
 
     // That is bad if the rational number type does not check for that
     // possibility during normalization.
@@ -1114,7 +1114,7 @@ BOOST_AUTO_TEST_CASE( ticket_5855_test )
 BOOST_AUTO_TEST_CASE( ticket_9067_test )
 {
     using boost::rational;
-    using boost::math::gcd;
+    using boost::integer::gcd;
 
     rational<int>  a( 6, -8 );
 

--- a/test/rational_test.cpp
+++ b/test/rational_test.cpp
@@ -443,7 +443,7 @@ typedef ::boost::mpl::list<short, int, long, MyInt>  all_signed_test_types;
 
 
 // Check if rational is the smallest size possible
-BOOST_GLOBAL_FIXTURE( rational_size_check )
+BOOST_GLOBAL_FIXTURE( rational_size_check );
 
 
 #if BOOST_CONTROL_RATIONAL_HAS_GCD
@@ -803,6 +803,15 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( rational_self_operations_test, T,
     BOOST_CHECK_EQUAL( r, rational_type( 0, 1) );
 
     BOOST_CHECK_THROW( r /= r, boost::bad_rational );
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE( gcd_and_lcm_on_rationals, T, all_signed_test_types )
+{
+    typedef boost::rational<T> rational;
+    BOOST_CHECK_EQUAL(boost::integer::gcd(rational(1, 4), rational(1, 3)),
+                      rational(1, 12));
+    BOOST_CHECK_EQUAL(boost::integer::lcm(rational(1, 4), rational(1, 3)),
+                      rational(1));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/rational_test.cpp
+++ b/test/rational_test.cpp
@@ -43,6 +43,7 @@
 #include <boost/operators.hpp>
 #include <boost/preprocessor/stringize.hpp>
 #include <boost/math/common_factor_rt.hpp>
+#include <boost/cstdint.hpp>
 
 #include <boost/rational.hpp>
 
@@ -990,12 +991,12 @@ BOOST_AUTO_TEST_CASE( rational_cast_test )
     //
     // Check assignments that should succeed from both wider and narrower types:
     //
-    boost::rational<int> rat;
-#ifndef BOOST_NO_LONG_LONG
-    long long ll, ll1(1);
-    unsigned long long ull, ull1(1);
-    int imax = (std::numeric_limits<int>::max)();
-    int imin = (std::numeric_limits<int>::min)();
+    boost::rational<boost::int32_t> rat;
+#ifndef BOOST_NO_INT64_T
+    boost::int64_t ll, ll1(1);
+    boost::uint64_t ull, ull1(1);
+    boost::int32_t imax = (std::numeric_limits<boost::int32_t>::max)();
+    boost::int32_t imin = (std::numeric_limits<boost::int32_t>::min)();
     ll = imax;
     rat.assign(ll, ll1);
     BOOST_CHECK_EQUAL(rat.numerator(), imax);
@@ -1019,18 +1020,18 @@ BOOST_AUTO_TEST_CASE( rational_cast_test )
     BOOST_CHECK_EQUAL(rat.numerator(), 0);
     BOOST_CHECK_EQUAL(rat.denominator(), 1);
 #endif
-    short smax = (std::numeric_limits<short>::max)();
-    short smin = (std::numeric_limits<short>::min)();
-    short s1 = 1;
+    boost::int16_t smax = (std::numeric_limits<boost::int16_t>::max)();
+    boost::int16_t smin = (std::numeric_limits<boost::int16_t>::min)();
+    boost::int16_t s1 = 1;
     rat.assign(smax, s1);
     BOOST_CHECK_EQUAL(rat.numerator(), smax);
     BOOST_CHECK_EQUAL(rat.denominator(), 1);
     rat.assign(smin, s1);
     BOOST_CHECK_EQUAL(rat.numerator(), smin);
     BOOST_CHECK_EQUAL(rat.denominator(), 1);
-    unsigned short usmax = (std::numeric_limits<unsigned short>::max)();
-    unsigned short usmin = (std::numeric_limits<unsigned short>::min)();
-    unsigned short us1 = 1;
+    boost::uint16_t usmax = (std::numeric_limits<boost::uint16_t>::max)();
+    boost::uint16_t usmin = (std::numeric_limits<boost::uint16_t>::min)();
+    boost::uint16_t us1 = 1;
     rat.assign(usmax, us1);
     BOOST_CHECK_EQUAL(rat.numerator(), usmax);
     BOOST_CHECK_EQUAL(rat.denominator(), 1);
@@ -1040,10 +1041,10 @@ BOOST_AUTO_TEST_CASE( rational_cast_test )
     //
     // Over again with unsigned rational:
     //
-    boost::rational<unsigned> urat;
-    unsigned uimax = (std::numeric_limits<unsigned>::max)();
-    unsigned uimin = (std::numeric_limits<unsigned>::min)();
-#ifndef BOOST_NO_LONG_LONG
+    boost::rational<boost::uint32_t> urat;
+    unsigned uimax = (std::numeric_limits<boost::uint32_t>::max)();
+    unsigned uimin = (std::numeric_limits<boost::uint32_t>::min)();
+#ifndef BOOST_NO_INT64_T
     ll = uimax;
     urat.assign(ll, ll1);
     BOOST_CHECK_EQUAL(urat.numerator(), uimax);

--- a/test/rational_test.cpp
+++ b/test/rational_test.cpp
@@ -977,6 +977,126 @@ BOOST_AUTO_TEST_CASE( rational_cast_test )
     // Converting constructor should throw if a bad rational number results:
     //
     BOOST_CHECK_THROW(boost::rational<short>(boost::rational<long>(1, 1 << sizeof(short) * CHAR_BIT)), boost::bad_rational);
+    //
+    // New tests from checked narrowing conversions:
+    //
+    BOOST_CHECK_THROW(boost::rational<unsigned>(-1), boost::bad_rational);
+    BOOST_CHECK_THROW(boost::rational<unsigned>(-1, 1), boost::bad_rational);
+    BOOST_CHECK_THROW(boost::rational<unsigned>(1, -1), boost::bad_rational);
+    unsigned ui_max = (std::numeric_limits<unsigned>::max)();
+    BOOST_CHECK_THROW(boost::rational<int>(static_cast<unsigned>(ui_max)), boost::bad_rational);
+    BOOST_CHECK_THROW(boost::rational<int>(ui_max, 1u), boost::bad_rational);
+    BOOST_CHECK_THROW(boost::rational<int>(1u, ui_max), boost::bad_rational);
+    //
+    // Check assignments that should succeed from both wider and narrower types:
+    //
+    boost::rational<int> rat;
+#ifndef BOOST_NO_LONG_LONG
+    long long ll, ll1(1);
+    unsigned long long ull, ull1(1);
+    int imax = (std::numeric_limits<int>::max)();
+    int imin = (std::numeric_limits<int>::min)();
+    ll = imax;
+    rat.assign(ll, ll1);
+    BOOST_CHECK_EQUAL(rat.numerator(), imax);
+    BOOST_CHECK_EQUAL(rat.denominator(), 1);
+    ++ll;
+    BOOST_CHECK_THROW(rat.assign(ll, ll1), boost::bad_rational);
+    ll = imin;
+    rat.assign(ll, ll1);
+    BOOST_CHECK_EQUAL(rat.numerator(), imin);
+    BOOST_CHECK_EQUAL(rat.denominator(), 1);
+    --ll;
+    BOOST_CHECK_THROW(rat.assign(ll, ll1), boost::bad_rational);
+    ull = imax;
+    rat.assign(ull, ull1);
+    BOOST_CHECK_EQUAL(rat.numerator(), imax);
+    BOOST_CHECK_EQUAL(rat.denominator(), 1);
+    ++ull;
+    BOOST_CHECK_THROW(rat.assign(ull, ull1), boost::bad_rational);
+    ull = 0;
+    rat.assign(ull, ull1);
+    BOOST_CHECK_EQUAL(rat.numerator(), 0);
+    BOOST_CHECK_EQUAL(rat.denominator(), 1);
+#endif
+    short smax = (std::numeric_limits<short>::max)();
+    short smin = (std::numeric_limits<short>::min)();
+    short s1 = 1;
+    rat.assign(smax, s1);
+    BOOST_CHECK_EQUAL(rat.numerator(), smax);
+    BOOST_CHECK_EQUAL(rat.denominator(), 1);
+    rat.assign(smin, s1);
+    BOOST_CHECK_EQUAL(rat.numerator(), smin);
+    BOOST_CHECK_EQUAL(rat.denominator(), 1);
+    unsigned short usmax = (std::numeric_limits<unsigned short>::max)();
+    unsigned short usmin = (std::numeric_limits<unsigned short>::min)();
+    unsigned short us1 = 1;
+    rat.assign(usmax, us1);
+    BOOST_CHECK_EQUAL(rat.numerator(), usmax);
+    BOOST_CHECK_EQUAL(rat.denominator(), 1);
+    rat.assign(usmin, us1);
+    BOOST_CHECK_EQUAL(rat.numerator(), usmin);
+    BOOST_CHECK_EQUAL(rat.denominator(), 1);
+    //
+    // Over again with unsigned rational:
+    //
+    boost::rational<unsigned> urat;
+    unsigned uimax = (std::numeric_limits<unsigned>::max)();
+    unsigned uimin = (std::numeric_limits<unsigned>::min)();
+#ifndef BOOST_NO_LONG_LONG
+    ll = uimax;
+    urat.assign(ll, ll1);
+    BOOST_CHECK_EQUAL(urat.numerator(), uimax);
+    BOOST_CHECK_EQUAL(urat.denominator(), 1);
+    ++ll;
+    BOOST_CHECK_THROW(urat.assign(ll, ll1), boost::bad_rational);
+    ll = uimin;
+    urat.assign(ll, ll1);
+    BOOST_CHECK_EQUAL(urat.numerator(), uimin);
+    BOOST_CHECK_EQUAL(urat.denominator(), 1);
+    --ll;
+    BOOST_CHECK_THROW(urat.assign(ll, ll1), boost::bad_rational);
+    ull = uimax;
+    urat.assign(ull, ull1);
+    BOOST_CHECK_EQUAL(urat.numerator(), uimax);
+    BOOST_CHECK_EQUAL(urat.denominator(), 1);
+    ++ull;
+    BOOST_CHECK_THROW(urat.assign(ull, ull1), boost::bad_rational);
+    ull = 0;
+    urat.assign(ull, ull1);
+    BOOST_CHECK_EQUAL(urat.numerator(), 0);
+    BOOST_CHECK_EQUAL(urat.denominator(), 1);
+#endif
+    smin = 0;
+    s1 = 1;
+    urat.assign(smax, s1);
+    BOOST_CHECK_EQUAL(urat.numerator(), smax);
+    BOOST_CHECK_EQUAL(urat.denominator(), 1);
+    urat.assign(smin, s1);
+    BOOST_CHECK_EQUAL(urat.numerator(), smin);
+    BOOST_CHECK_EQUAL(urat.denominator(), 1);
+    urat.assign(usmax, us1);
+    BOOST_CHECK_EQUAL(urat.numerator(), usmax);
+    BOOST_CHECK_EQUAL(urat.denominator(), 1);
+    urat.assign(usmin, us1);
+    BOOST_CHECK_EQUAL(urat.numerator(), usmin);
+    BOOST_CHECK_EQUAL(urat.denominator(), 1);
+    //
+    // Conversions that must not be allowed:
+    //
+    BOOST_STATIC_ASSERT(!boost::is_convertible<float, boost::rational<int> >::value);
+    BOOST_STATIC_ASSERT(!boost::is_convertible<double, boost::rational<int> >::value);
+    BOOST_STATIC_ASSERT(!boost::is_convertible<long double, boost::rational<int> >::value);
+    // And ones that should:
+    BOOST_STATIC_ASSERT(boost::is_convertible<char, boost::rational<int> >::value);
+    BOOST_STATIC_ASSERT(boost::is_convertible<signed char, boost::rational<int> >::value);
+    BOOST_STATIC_ASSERT(boost::is_convertible<unsigned char, boost::rational<int> >::value);
+    BOOST_STATIC_ASSERT(boost::is_convertible<short, boost::rational<int> >::value);
+    BOOST_STATIC_ASSERT(boost::is_convertible<unsigned short, boost::rational<int> >::value);
+    BOOST_STATIC_ASSERT(boost::is_convertible<int, boost::rational<int> >::value);
+    BOOST_STATIC_ASSERT(boost::is_convertible<unsigned int, boost::rational<int> >::value);
+    BOOST_STATIC_ASSERT(boost::is_convertible<long, boost::rational<int> >::value);
+    BOOST_STATIC_ASSERT(boost::is_convertible<unsigned long, boost::rational<int> >::value);
 }
 
 #ifndef BOOST_NO_MEMBER_TEMPLATES


### PR DESCRIPTION
This change disallows conversion from floating-point types - which brings the library into line with it's documentation.  Currently:

rational<int> r(0.1);

compiles just fine, but doesn't generate any kind of sensible answer.  See discussion: http://lists.boost.org/Archives/boost/2014/07/215504.php

Note that this change includes (and depends upon) two previous pull requests:
https://github.com/boostorg/rational/pull/2
https://github.com/boostorg/rational/pull/3

The only breaking change I can detect with this commit is a currently untested one:

constexpr rational<short> r(3); // fails

this works however:

constexpr rational<short> r(static_cast<short>(3)); // OK

While this is might be fixable, frankly I don't see the point - I suspect that real world usage of rational with shorter-than-int-types is vanishlingly small?
