### PR TITLE
Fix test compile break

### DIFF
--- a/test/rational_test.cpp
+++ b/test/rational_test.cpp
@@ -442,7 +442,7 @@ typedef ::boost::mpl::list<short, int, long, MyInt>  all_signed_test_types;
 
 
 // Check if rational is the smallest size possible
-BOOST_GLOBAL_FIXTURE( rational_size_check )
+BOOST_GLOBAL_FIXTURE( rational_size_check );
 
 
 #if BOOST_CONTROL_RATIONAL_HAS_GCD


### PR DESCRIPTION
A semicolon is now required after BOOST_GLOBAL_FIXTURE because of https://github.com/boostorg/test/commit/3f7216db3db2e11a768d8d0c8bb18632f106c466.
