### PR TITLE
pow and reciprocal for rationals.

### DIFF
--- a/include/boost/rational.hpp
+++ b/include/boost/rational.hpp
@@ -143,6 +143,9 @@ class rational :
     struct helper { IntType parts[2]; };
     typedef IntType (helper::* bool_type)[2];
 
+    class already_normalized {};
+    rational(already_normalized, param_type n, param_type d) : num(n), den(d) {}
+
 public:
     // Component type
     typedef IntType int_type;
@@ -220,6 +223,13 @@ public:
     bool operator> (param_type i) const;
     BOOST_CONSTEXPR
     bool operator== (param_type i) const;
+
+    rational<IntType> reciprocal() const
+    {
+        if (num == IntType(0)) BOOST_THROW_EXCEPTION(bad_rational());
+
+        return rational<IntType>(already_normalized(), den, num);
+    }
 
 private:
     // Implementation - numerator and denominator (normalized).
@@ -669,6 +679,21 @@ template <typename IntType>
 inline rational<IntType> abs(const rational<IntType>& r)
 {
     return r.numerator() >= IntType(0)? r: -r;
+}
+
+template <typename IntType>
+inline rational<IntType> pow(rational<IntType> const& base, IntType exponent)
+{
+    if (!base) return base;
+    bool const positive = exponent >= 0;
+    rational<IntType> result(exponent % 2 != 0? base: rational<IntType>(1));
+    rational<IntType> x(base);
+    if (!positive) exponent = -exponent;
+    while ((exponent /= 2) > 0) {
+        x *= x;
+        if ((exponent % 2) == 1) result *= x;
+    }
+    return positive? result: result.reciprocal();
 }
 
 namespace integer {

--- a/include/boost/rational.hpp
+++ b/include/boost/rational.hpp
@@ -224,12 +224,7 @@ public:
     BOOST_CONSTEXPR
     bool operator== (param_type i) const;
 
-    rational<IntType> reciprocal() const
-    {
-        if (num == IntType(0)) BOOST_THROW_EXCEPTION(bad_rational());
-
-        return rational<IntType>(already_normalized(), den, num);
-    }
+    rational<IntType> reciprocal() const;
 
 private:
     // Implementation - numerator and denominator (normalized).
@@ -542,6 +537,20 @@ inline bool rational<IntType>::operator== (param_type i) const
     return ((den == IntType(1)) && (num == i));
 }
 
+template <typename IntType>
+rational<IntType> rational<IntType>::reciprocal() const
+{
+    IntType const zero(0);
+
+    if (num == zero)
+        BOOST_THROW_EXCEPTION(bad_rational());
+
+    if (num < zero)
+        return rational<IntType>(already_normalized(), -den, -num);
+
+    return rational<IntType>(already_normalized(), den, num);
+}
+
 // Invariant check
 template <typename IntType>
 inline bool rational<IntType>::test_invariant() const
@@ -688,11 +697,12 @@ inline rational<IntType> pow(rational<IntType> const& base, IntType exponent)
     bool const positive = exponent >= 0;
     rational<IntType> result(exponent % 2 != 0? base: rational<IntType>(1));
     rational<IntType> x(base);
-    if (!positive) exponent = -exponent;
-    while ((exponent /= 2) > 0) {
+
+    while ((exponent /= 2) != 0) {
         x *= x;
-        if ((exponent % 2) == 1) result *= x;
+        if (exponent % 2 != 0) result *= x;
     }
+
     return positive? result: result.reciprocal();
 }
 

--- a/test/rational_test.cpp
+++ b/test/rational_test.cpp
@@ -642,6 +642,27 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( rational_abs_test, T, all_signed_test_types )
     BOOST_CHECK_EQUAL( abs(r8), rational_type(2, 3) );
 }
 
+// Power tests
+BOOST_AUTO_TEST_CASE_TEMPLATE( rational_pow_test, T, all_signed_test_types )
+{
+    typedef boost::rational<T> rational_type;
+
+    BOOST_CHECK_EQUAL( pow(rational_type(2), T(-3)), rational_type(1, 8) );
+    BOOST_CHECK_EQUAL( pow(rational_type(2), T(-2)), rational_type(1, 4) );
+    BOOST_CHECK_EQUAL( pow(rational_type(2), T(-1)), rational_type(1, 2) );
+    BOOST_CHECK_EQUAL( pow(rational_type(2), T( 0)), rational_type(1) );
+    BOOST_CHECK_EQUAL( pow(rational_type(2), T( 1)), rational_type(2) );
+    BOOST_CHECK_EQUAL( pow(rational_type(2), T( 2)), rational_type(4) );
+    BOOST_CHECK_EQUAL( pow(rational_type(2), T( 3)), rational_type(8) );
+
+    BOOST_CHECK_EQUAL( pow(rational_type(1, 3), T(3)), rational_type(1, 27) );
+    BOOST_CHECK_EQUAL( pow(rational_type(2, 3), T(3)), rational_type(8, 27) );
+    BOOST_CHECK_EQUAL( pow(rational_type(1, 5), T(5)), rational_type(1, 3125) );
+    BOOST_CHECK_EQUAL( pow(rational_type(2, 5), T(5)), rational_type(32, 3125) );
+    BOOST_CHECK_EQUAL( pow(rational_type(3, 5), T(5)), rational_type(243, 3125) );
+    BOOST_CHECK_EQUAL( pow(rational_type(4, 5), T(5)), rational_type(1024, 3125) );
+}
+
 // Unary operator tests
 BOOST_AUTO_TEST_CASE_TEMPLATE( rational_unary_test, T, all_signed_test_types )
 {

--- a/test/rational_test.cpp
+++ b/test/rational_test.cpp
@@ -647,6 +647,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( rational_pow_test, T, all_signed_test_types )
 {
     typedef boost::rational<T> rational_type;
 
+    BOOST_CHECK_EQUAL( pow(rational_type(2), T(-4)), rational_type(1, 16) );
     BOOST_CHECK_EQUAL( pow(rational_type(2), T(-3)), rational_type(1, 8) );
     BOOST_CHECK_EQUAL( pow(rational_type(2), T(-2)), rational_type(1, 4) );
     BOOST_CHECK_EQUAL( pow(rational_type(2), T(-1)), rational_type(1, 2) );
@@ -654,6 +655,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( rational_pow_test, T, all_signed_test_types )
     BOOST_CHECK_EQUAL( pow(rational_type(2), T( 1)), rational_type(2) );
     BOOST_CHECK_EQUAL( pow(rational_type(2), T( 2)), rational_type(4) );
     BOOST_CHECK_EQUAL( pow(rational_type(2), T( 3)), rational_type(8) );
+    BOOST_CHECK_EQUAL( pow(rational_type(2), T( 4)), rational_type(16) );
+
+    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T(-4)), rational_type(16) );
+    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T(-3)), rational_type(-8) );
+    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T(-2)), rational_type(4) );
+    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T(-1)), rational_type(-2) );
+    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T( 0)), rational_type(1) );
+    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T( 1)), rational_type(-1, 2) );
+    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T( 2)), rational_type(1, 4) );
+    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T( 3)), rational_type(-1, 8) );
+    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T( 4)), rational_type(1, 16) );
 
     BOOST_CHECK_EQUAL( pow(rational_type(1, 3), T(3)), rational_type(1, 27) );
     BOOST_CHECK_EQUAL( pow(rational_type(2, 3), T(3)), rational_type(8, 27) );


### PR DESCRIPTION
reciprocal() implements 1/x without a need for gcd. pow implements a decently
efficient power function for rational base and integer exponent.

Tests included.
