### PR TITLE
std::-qualify mention of string

### DIFF
--- a/include/boost/rational.hpp
+++ b/include/boost/rational.hpp
@@ -642,7 +642,7 @@ std::ostream& operator<< (std::ostream& os, const rational<IntType>& r)
     ss << noshowpos << noshowbase << '/' << r.denominator();
 
     // The numerator holds the showpos, internal, and showbase flags.
-    string const   tail = ss.str();
+    std::string const   tail = ss.str();
     streamsize const  w = os.width() - static_cast<streamsize>( tail.size() );
 
     ss.clear();


### PR DESCRIPTION
Even with `using namespace std`, an unqualified mention of `string` is ambiguous if the user has defined `string` as a name in the global namespace.
