### PR TITLE
Comparators should be const member.

### DIFF
--- a/include/boost/rational.hpp
+++ b/include/boost/rational.hpp
@@ -342,7 +342,7 @@ public:
     bool operator== (const rational& r) const;
 
     template <class T>
-    typename boost::enable_if_c<rational_detail::is_compatible_integer<T, IntType>::value, bool>::type operator< (const T& i)
+    typename boost::enable_if_c<rational_detail::is_compatible_integer<T, IntType>::value, bool>::type operator< (const T& i) const
     {
        // Avoid repeated construction
        int_type const  zero(0);
@@ -359,12 +359,12 @@ public:
        return q < i;
     }
     template <class T>
-    typename boost::enable_if_c<rational_detail::is_compatible_integer<T, IntType>::value, bool>::type operator>(const T& i)
+    typename boost::enable_if_c<rational_detail::is_compatible_integer<T, IntType>::value, bool>::type operator>(const T& i) const
     {
        return operator==(i) ? false : !operator<(i);
     }
     template <class T>
-    BOOST_CONSTEXPR typename boost::enable_if_c<rational_detail::is_compatible_integer<T, IntType>::value, bool>::type operator== (const T& i)
+    BOOST_CONSTEXPR typename boost::enable_if_c<rational_detail::is_compatible_integer<T, IntType>::value, bool>::type operator== (const T& i) const
     {
        return ((den == IntType(1)) && (num == i));
     }

--- a/test/rational_test.cpp
+++ b/test/rational_test.cpp
@@ -551,9 +551,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( rational_comparison_test, T,
  all_signed_test_types )
 {
     my_configuration::hook<T>  h;
-    boost::rational<T>  &r1 = h.r_[ 0 ], &r2 = h.r_[ 1 ], &r3 = h.r_[ 2 ],
-                        &r4 = h.r_[ 3 ], &r5 = h.r_[ 4 ], &r6 = h.r_[ 5 ],
-                        &r7 = h.r_[ 6 ], &r8 = h.r_[ 7 ], &r9 = h.r_[ 8 ];
+    const boost::rational<T>  &r1 = h.r_[ 0 ], &r2 = h.r_[ 1 ], &r3 = h.r_[ 2 ],
+                              &r4 = h.r_[ 3 ], &r5 = h.r_[ 4 ], &r6 = h.r_[ 5 ],
+                              &r7 = h.r_[ 6 ], &r8 = h.r_[ 7 ], &r9 = h.r_[ 8 ];
 
     BOOST_CHECK( r1 == r2 );
     BOOST_CHECK( r2 != r3 );


### PR DESCRIPTION
Additionally, c++11 non-static constexpr is implicitly const member, but after c++14 it isn't. Some compilers with c++11 mode warn about that (see [rational / clang-linux-3.8~gnu++11](http://www.boost.org/development/tests/develop/output/Flast-FreeBSD11-rational-clang-linux-3-8~gnu++11-warnings.html)).

Tested on both of GCC 5.4.0 and Clang 3.8.1 with gnu++98, gnu++11, and gnu++14 mode.