### PR TITLE
Remove sudo commands from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,7 @@ jobs:
           sources:
             - ubuntu-toolchain-r-test
       script:
-        - pushd /tmp && git clone https://github.com/linux-test-project/lcov.git && cd lcov && sudo make install && which lcov && lcov --version && popd
+        - pushd /tmp && git clone https://github.com/linux-test-project/lcov.git && export PATH=/tmp/lcov/bin:$PATH && which lcov && lcov --version && popd
         - cd $BOOST_ROOT/libs/$SELF
         - ci/travis/codecov.sh
 
@@ -153,7 +153,7 @@ jobs:
         - COMMENT="Coverity Scan"
         - TOOLSET=gcc
       script:
-        - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+ #      - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
         - cd $BOOST_ROOT/libs/$SELF
         - ci/travis/coverity.sh
 


### PR DESCRIPTION
Fixes the failing code coverage build job in Travis CI.
(hopefully) Fixes the Coverity Scan job from suffering the same sudo failure fate.