### PR TITLE
Revert "Add pow method"

### DIFF
--- a/include/boost/rational.hpp
+++ b/include/boost/rational.hpp
@@ -21,7 +21,6 @@
 //    Nickolay Mladenov, for the implementation of operator+=
 
 //  Revision History
-//  14 Jun 18  Add pow
 //  02 Sep 13  Remove unneeded forward declarations; tweak private helper
 //             function (Daryle Walker)
 //  30 Aug 13  Improve exception safety of "assign"; start modernizing I/O code
@@ -841,7 +840,7 @@ template <typename IntType>
 void rational<IntType>::normalize()
 {
     // Avoid repeated construction
-    IntType const zero(0);
+    IntType zero(0);
 
     if (den == zero)
        BOOST_THROW_EXCEPTION(bad_rational());
@@ -857,8 +856,9 @@ void rational<IntType>::normalize()
     num /= g;
     den /= g;
 
-    if (den < -(std::numeric_limits<IntType>::max)())
+    if (den < -(std::numeric_limits<IntType>::max)()) {
         BOOST_THROW_EXCEPTION(bad_rational("bad rational: non-zero singular denominator"));
+    }
 
     // Ensure that the denominator is positive
     if (den < zero) {
@@ -867,23 +867,6 @@ void rational<IntType>::normalize()
     }
 
     BOOST_ASSERT( this->test_invariant() );
-}
-
-template <typename IntType>
-inline rational<IntType> pow(rational<IntType> base, IntType exponent)
-{
-    if (!base)
-        return base;
-    bool const positive = exponent >= 0;
-    rational<IntType> result((exponent % 2 != 0) ? base : rational<IntType>(1));
-
-    while ((exponent /= 2) != 0) {
-        base *= base;
-        if ((exponent % 2) != 0)
-            result *= base;
-    }
-
-    return positive ? result : (static_cast<IntType>(1) / result);
 }
 
 #ifndef BOOST_NO_IOSTREAM

--- a/test/rational_test.cpp
+++ b/test/rational_test.cpp
@@ -19,7 +19,6 @@
 // since he hasn't been in contact for years.)
 
 // Revision History
-// 14 Jun 18  Added pow tests
 // 30 Aug 13  Add bug-test of assignments holding the basic and/or strong
 //            guarantees (Daryle Walker)
 // 27 Aug 13  Add test for cross-version constructor template (Daryle Walker)
@@ -1604,41 +1603,6 @@ BOOST_AUTO_TEST_CASE( ticket_9067_test )
     BOOST_CHECK_EQUAL( a.numerator(), -3 );
     BOOST_CHECK_EQUAL( a.denominator(), 4 );
 #endif
-}
-
-// Power tests
-BOOST_AUTO_TEST_CASE_TEMPLATE( rational_pow_test, T, all_signed_test_types )
-{
-    typedef boost::rational<T> rational_type;
-
-    BOOST_CHECK_EQUAL( pow(rational_type(0), T( 0)), rational_type(0) );
-
-    BOOST_CHECK_EQUAL( pow(rational_type(2), T(-4)), rational_type(1, 16) );
-    BOOST_CHECK_EQUAL( pow(rational_type(2), T(-3)), rational_type(1, 8) );
-    BOOST_CHECK_EQUAL( pow(rational_type(2), T(-2)), rational_type(1, 4) );
-    BOOST_CHECK_EQUAL( pow(rational_type(2), T(-1)), rational_type(1, 2) );
-    BOOST_CHECK_EQUAL( pow(rational_type(2), T( 0)), rational_type(1) );
-    BOOST_CHECK_EQUAL( pow(rational_type(2), T( 1)), rational_type(2) );
-    BOOST_CHECK_EQUAL( pow(rational_type(2), T( 2)), rational_type(4) );
-    BOOST_CHECK_EQUAL( pow(rational_type(2), T( 3)), rational_type(8) );
-    BOOST_CHECK_EQUAL( pow(rational_type(2), T( 4)), rational_type(16) );
-
-    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T(-4)), rational_type(16) );
-    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T(-3)), rational_type(-8) );
-    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T(-2)), rational_type(4) );
-    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T(-1)), rational_type(-2) );
-    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T( 0)), rational_type(1) );
-    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T( 1)), rational_type(-1, 2) );
-    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T( 2)), rational_type(1, 4) );
-    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T( 3)), rational_type(-1, 8) );
-    BOOST_CHECK_EQUAL( pow(rational_type(-1, 2), T( 4)), rational_type(1, 16) );
-
-    BOOST_CHECK_EQUAL( pow(rational_type(1, 3), T(3)), rational_type(1, 27) );
-    BOOST_CHECK_EQUAL( pow(rational_type(2, 3), T(3)), rational_type(8, 27) );
-    BOOST_CHECK_EQUAL( pow(rational_type(1, 5), T(5)), rational_type(1, 3125) );
-    BOOST_CHECK_EQUAL( pow(rational_type(2, 5), T(5)), rational_type(32, 3125) );
-    BOOST_CHECK_EQUAL( pow(rational_type(3, 5), T(5)), rational_type(243, 3125) );
-    BOOST_CHECK_EQUAL( pow(rational_type(4, 5), T(5)), rational_type(1024, 3125) );
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This reverts commit 25ad8e5a5cc382c483dde8d6c019ba970b443f62.

During beta testing it was found the addition of boost::pow broke some code.  More details can be found here:

https://github.com/boostorg/rational/pull/23

Corresponding release note change:

https://github.com/boostorg/website/pull/350