### PR TITLE
[CMake] Add minimal cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries( boost_rational
         Boost::utility
 )
 
-if( BOOST_RATIONA_INCLUDE_TESTS )
+if( BOOST_RATIONAL_INCLUDE_TESTS )
     enable_testing()
     add_subdirectory( test )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 cmake_minimum_required( VERSION 3.5 )
 project( BoostRational LANGUAGES CXX)
-option( BOOST_RATIONA_INCLUDE_TESTS "Add boost rational tests" OFF )
+option( BOOST_RATIONAL_INCLUDE_TESTS "Add boost rational tests" OFF )
 
 add_library( boost_rational INTERFACE )
 add_library( Boost::rational ALIAS boost_rational )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright 2019 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Rational is currently experimental at best
+#       and the interface is likely to change in the future
+
+cmake_minimum_required(VERSION 3.5)
+project( BoostRational LANGUAGES CXX)
+
+add_library( boost_rational INTERFACE )
+add_library( Boost::rational ALIAS boost_rational )
+
+target_include_directories( boost_rational INTERFACE include )
+
+target_link_libraries( boost_rational
+    INTERFACE
+        Boost::assert
+        Boost::config
+        Boost::core
+        Boost::integer
+        Boost::static_assert
+        Boost::throw_exception
+        Boost::type_traits
+        Boost::utility
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,9 @@
 # NOTE: CMake support for Boost.Rational is currently experimental at best
 #       and the interface is likely to change in the future
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required( VERSION 3.5 )
 project( BoostRational LANGUAGES CXX)
+option( BOOST_RATIONA_INCLUDE_TESTS "Add boost rational tests" OFF )
 
 add_library( boost_rational INTERFACE )
 add_library( Boost::rational ALIAS boost_rational )
@@ -24,4 +25,9 @@ target_link_libraries( boost_rational
         Boost::type_traits
         Boost::utility
 )
+
+if( BOOST_RATIONA_INCLUDE_TESTS )
+    enable_testing()
+    add_subdirectory( test )
+endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright 2019 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Rational is currently experimental at best
+#       and the interface is likely to change in the future
+
+#add_executable( test_boost_rational_test rational_test.cpp )
+#target_link_libraries( test_boost_rational_test
+#	PUBLIC
+#		Boost::rational
+#		Boost::mpl
+#       Boost::test
+#)
+#add_test( NAME test_boost_rational_test COMMAND test_boost_rational_test )
+
+add_executable( test_boost_rational_constexpr_test constexpr_test.cpp )
+target_link_libraries( test_boost_rational_constexpr_test
+	PUBLIC
+		Boost::rational
+)
+
+add_test( NAME test_boost_rational_constexpr_test COMMAND test_boost_rational_constexpr_test )
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,19 +5,20 @@
 # NOTE: CMake support for Boost.Rational is currently experimental at best
 #       and the interface is likely to change in the future
 
-#add_executable( test_boost_rational_test rational_test.cpp )
-#target_link_libraries( test_boost_rational_test
-#	PUBLIC
-#		Boost::rational
-#		Boost::mpl
-#       Boost::test
-#)
-#add_test( NAME test_boost_rational_test COMMAND test_boost_rational_test )
+# NOTE: Boost::test not yet available, so we can't run the regular test
+# add_executable( test_boost_rational_test rational_test.cpp )
+# target_link_libraries( test_boost_rational_test
+#     PUBLIC
+#         Boost::rational
+#         Boost::mpl
+#         Boost::test
+# )
+# add_test( NAME test_boost_rational_test COMMAND test_boost_rational_test )
 
 add_executable( test_boost_rational_constexpr_test constexpr_test.cpp )
 target_link_libraries( test_boost_rational_constexpr_test
-	PUBLIC
-		Boost::rational
+    PUBLIC
+        Boost::rational
 )
 
 add_test( NAME test_boost_rational_constexpr_test COMMAND test_boost_rational_constexpr_test )


### PR DESCRIPTION
- CMake file only supports add_subdirectory workflow.
- Provides Boost::rational target
- Does not support installation
- Does not compile/run unit tests