### PR TITLE
Update Travis CI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 # Copyright 2016 Peter Dimov
-# Copyright 2017, 2018 James E. King III
+# Copyright 2017 - 2019 James E. King III
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
 #
 # Generic Travis CI build script for boostorg repositories
-# See: https://github.com/jeking3/boost-ci
+# See: https://github.com/boostorg/boost-ci
 #
 # Instructions for customizing this script for your library:
 # 
@@ -22,8 +22,7 @@
 #
 # That's it - the scripts will do everything else for you.
 
-sudo: false
-dist: trusty
+dist: xenial
 language: cpp
 
 env:
@@ -36,7 +35,7 @@ env:
     - B2_VARIANT=variant=release,debug
 
 install:
-  - git clone https://github.com/jeking3/boost-ci.git boost-ci
+  - git clone https://github.com/boostorg/boost-ci.git boost-ci
   - cp -pr boost-ci/ci boost-ci/.codecov.yml .
   - source ci/travis/install.sh
 
@@ -67,23 +66,30 @@ script:
 #
 
 anchors:
-  clang-34: &clang-34 { apt: { packages: [ "clang-3.4"       ], sources: [ "llvm-toolchain-trusty-3.4" ] } }
   clang-38: &clang-38 { apt: { packages: [ "clang-3.8",
-                                           "libstdc++-6-dev" ], sources: [ "llvm-toolchain-trusty-3.8",
+                                           "libstdc++-6-dev" ], sources: [ "llvm-toolchain-xenial-3.8",
                                                                            "ubuntu-toolchain-r-test"   ] } }
   clang-4:  &clang-4  { apt: { packages: [ "clang-4.0",
-                                           "libstdc++-6-dev" ], sources: [ "llvm-toolchain-trusty-4.0",
+                                           "libstdc++-6-dev" ], sources: [ "llvm-toolchain-xenial-4.0",
                                                                            "ubuntu-toolchain-r-test"   ] } }
   clang-5:  &clang-5  { apt: { packages: [ "clang-5.0",
-                                           "libstdc++-7-dev" ], sources: [ "llvm-toolchain-trusty-5.0",
+                                           "libstdc++-7-dev" ], sources: [ "llvm-toolchain-xenial-5.0",
                                                                            "ubuntu-toolchain-r-test"   ] } }
   clang-6:  &clang-6  { apt: { packages: [ "clang-6.0",
+                                           "libc6-dbg",
                                            "libc++-dev",
-                                           "libstdc++-8-dev",
-                                           "valgrind"        ], sources: [ "llvm-toolchain-trusty-6.0",
+                                           "libstdc++-8-dev" ], sources: [ "llvm-toolchain-xenial-6.0",
                                                                            "ubuntu-toolchain-r-test"   ] } }
-  gcc-44:   &gcc-44   { apt: { packages: [ "g++-4.4"         ], sources: [ "ubuntu-toolchain-r-test"   ] } }
-  gcc-46:   &gcc-46   { apt: { packages: [ "g++-4.6"         ], sources: [ "ubuntu-toolchain-r-test"   ] } }
+  clang-7:  &clang-7  { apt: { packages: [ "clang-7",
+                                           "libc6-dbg",
+                                           "libc++-dev",
+                                           "libstdc++-8-dev" ], sources: [ "llvm-toolchain-xenial-7",
+                                                                           "ubuntu-toolchain-r-test"   ] } }
+  clang-8:  &clang-8  { apt: { packages: [ "clang-8",
+                                           "libc6-dbg",
+                                           "libc++-dev",
+                                           "libstdc++-8-dev" ], sources: [ "llvm-toolchain-xenial-8",
+                                                                           "ubuntu-toolchain-r-test"   ] } }
   gcc-48:   &gcc-48   { apt: { packages: [ "g++-4.8"         ], sources: [ "ubuntu-toolchain-r-test"   ] } }
   gcc-5:    &gcc-5    { apt: { packages: [ "g++-5"           ], sources: [ "ubuntu-toolchain-r-test"   ] } }
   gcc-6:    &gcc-6    { apt: { packages: [ "g++-6"           ], sources: [ "ubuntu-toolchain-r-test"   ] } }
@@ -92,47 +98,37 @@ anchors:
 
 jobs:
   allow_failures:
-    # gcc-4.6 internal compiler error
     - env:
-      - TOOLSET=gcc-4.6
-      - CXXSTD=03,0x
-    # https://github.com/boostorg/test/issues/174
-    - env:
-      - COMMENT=ubsan
-      - B2_VARIANT=variant=debug
-      - TOOLSET=gcc-8
-      - CXXSTD=03,11,14,17,2a
-      - DEFINES="define=BOOST_NO_STRESS_TEST=1"
-      - CXXFLAGS="cxxflags=-fno-omit-frame-pointer cxxflags=-fsanitize=undefined cxxflags=-fno-sanitize-recover=undefined"
-      - LINKFLAGS="linkflags=-fsanitize=undefined linkflags=-fno-sanitize-recover=undefined linkflags=-fuse-ld=gold"
-      - UBSAN_OPTIONS=print_stacktrace=1
+      - COPY="all the environment settings from your job"
 
   include:
     # libstdc++
-    - { os: "linux", env: [ "TOOLSET=gcc-4.4",   "CXXSTD=98,0x"          ], addons: *gcc-44    }
-    - { os: "linux", env: [ "TOOLSET=gcc-4.6",   "CXXSTD=03,0x"          ], addons: *gcc-46    }
-    - { os: "linux", env: [ "TOOLSET=gcc-4.8",   "CXXSTD=03,11"          ], addons: *gcc-48    }
-    - { os: "linux", env: [ "TOOLSET=gcc-5",     "CXXSTD=03,11"          ], addons: *gcc-5     }
-    - { os: "linux", env: [ "TOOLSET=gcc-6",     "CXXSTD=03,11,14"       ], addons: *gcc-6     }
-    - { os: "linux", env: [ "TOOLSET=gcc-7",     "CXXSTD=03,11,14,17"    ], addons: *gcc-7     }
-    - { os: "linux", env: [ "TOOLSET=gcc-8",     "CXXSTD=03,11,14,17,2a" ], addons: *gcc-8     }
-    - { os: "linux", env: [ "TOOLSET=clang-3.4", "CXXSTD=03,11"          ], addons: *clang-34  }
-    - { os: "linux", env: [ "TOOLSET=clang-3.8", "CXXSTD=03,11,14"       ], addons: *clang-38  }
-    - { os: "linux", env: [ "TOOLSET=clang-4.0", "CXXSTD=03,11,14"       ], addons: *clang-4   }
-    - { os: "linux", env: [ "TOOLSET=clang-5.0", "CXXSTD=03,11,14,17"    ], addons: *clang-5   }
-    - { os: "linux", env: [ "TOOLSET=clang-6.0", "CXXSTD=03,11,14,17,2a" ], addons: *clang-6   }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-4.8",     "B2_CXXSTD=03,11"    ], addons: *gcc-48    }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-5",       "B2_CXXSTD=11"       ], addons: *gcc-5     }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-6",       "B2_CXXSTD=11,14"    ], addons: *gcc-6     }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-7",       "B2_CXXSTD=11,14,17" ], addons: *gcc-7     }
+    - { os: "linux", env: [ "B2_TOOLSET=gcc-8",       "B2_CXXSTD=14,17,2a" ], addons: *gcc-8     }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-3.8",   "B2_CXXSTD=03,11,14" ], addons: *clang-38  }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-4.0",   "B2_CXXSTD=11,14"    ], addons: *clang-4   }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-5.0",   "B2_CXXSTD=11,14,17" ], addons: *clang-5   }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-6.0",   "B2_CXXSTD=14,17,2a" ], addons: *clang-6   }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-7",     "B2_CXXSTD=14,17,2a" ], addons: *clang-7   }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-8",     "B2_CXXSTD=14,17,2a" ], addons: *clang-8   }
+
     # libc++
-    - { os: "linux", env: [ "TOOLSET=clang-6.0", "CXXSTD=03,11,14,17,2a",
-                            "CXXFLAGS=-stdlib=libc++"                    ], addons: *clang-6   }
-  # the rvm environment on osx is taking over basic commands like "cd" and breaking things!
-  # - { os: "osx"  , env: [ "COMMENT=libc++",
-  #                         "TOOLSET=clang",     "CXXSTD=03,11,14"       ]                     }
+    - { os: "linux", env: [ "B2_TOOLSET=clang-6.0",   "B2_CXXSTD=03,11,14,17,2a",
+                            "B2_CXXFLAGS=-stdlib=libc++"                   ], addons: *clang-6   }
+    - { os: "osx"  , env: [ "B2_TOOLSET=clang",       "B2_CXXSTD=03,11,17" ]                     }
+                            
+  # to enable Intel ICC define INTEL_ICC_SERIAL_NUMBER and the following:
+  # - { os: "linux", env: [ "B2_TOOLSET=intel-linux", "B2_CXXSTD=11,14,17" ], addons: *gcc-7,
+  #     script: cd $BOOST_ROOT/libs/$SELF && ci/travis/intelicc.sh                               }
 
     - os: linux
       env: 
         - COMMENT=codecov.io
-        - TOOLSET=gcc-7
-        - DEFINES="define=BOOST_NO_STRESS_TEST=1"
+        - B2_TOOLSET=gcc-7
+        - B2_DEFINES="define=BOOST_NO_STRESS_TEST=1"
       addons: *gcc-7
       script:
         - pushd /tmp && git clone https://github.com/linux-test-project/lcov.git && export PATH=/tmp/lcov/bin:$PATH && which lcov && lcov --version && popd
@@ -150,24 +146,27 @@ jobs:
       env:
         - COMMENT=ubsan
         - B2_VARIANT=variant=debug
-        - TOOLSET=gcc-8
-        - CXXSTD=03,11,14,17,2a
-        - DEFINES="define=BOOST_NO_STRESS_TEST=1"
-        - CXXFLAGS="cxxflags=-fno-omit-frame-pointer cxxflags=-fsanitize=undefined cxxflags=-fno-sanitize-recover=undefined"
-        - LINKFLAGS="linkflags=-fsanitize=undefined linkflags=-fno-sanitize-recover=undefined linkflags=-fuse-ld=gold"
+        - B2_TOOLSET=gcc-8
+        - B2_CXXSTD=03,11,14,17,2a
+        - B2_DEFINES="define=BOOST_NO_STRESS_TEST=1"
+        - B2_CXXFLAGS="cxxflags=-fno-omit-frame-pointer cxxflags=-fsanitize=undefined cxxflags=-fno-sanitize-recover=undefined"
+        - B2_LINKFLAGS="linkflags=-fsanitize=undefined linkflags=-fno-sanitize-recover=undefined linkflags=-fuse-ld=gold"
         - UBSAN_OPTIONS=print_stacktrace=1
       addons: *gcc-8
 
     - os: linux
       env:
         - COMMENT=valgrind
-        - TOOLSET=clang-6.0
-        - CXXSTD=03,11,14,17,2a
-        - DEFINES="define=BOOST_NO_STRESS_TEST=1"
+        - B2_TOOLSET=clang-6.0
+        - B2_CXXSTD=03,11,14,17,2a
+        - B2_DEFINES="define=BOOST_NO_STRESS_TEST=1"
         - B2_VARIANT=variant=debug
-        - TESTFLAGS=testing.launcher=valgrind
+        - B2_TESTFLAGS=testing.launcher=valgrind
         - VALGRIND_OPTS=--error-exitcode=1
       addons: *clang-6
+      script:
+        - cd $BOOST_ROOT/libs/$SELF
+        - ci/travis/valgrind.sh
 
     #################### Jobs to run on pushes to master, develop ###################
 
@@ -176,7 +175,7 @@ jobs:
       if: (env(COVERITY_SCAN_NOTIFICATION_EMAIL) IS present) AND (branch IN (develop, master)) AND (type IN (cron, push))
       env:
         - COMMENT="Coverity Scan"
-        - TOOLSET=gcc-7
+        - B2_TOOLSET=gcc-7
       addons: *gcc-7
       script:
         - cd $BOOST_ROOT/libs/$SELF

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,16 @@
 # Copyright 2016, 2017 Peter Dimov
-# Copyright (C) 2017, 2018 James E. King III
+# Copyright (C) 2017 - 2019 James E. King III
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
 #
 # Generic Appveyor build script for boostorg repositories
-# See: https://github.com/jeking3/boost-ci/
+# See: https://github.com/boostorg/boost-ci/
 #
 # Instructions for customizing this script for your library:
 #
 # 1. Customize the compilers and language levels you want.
-# 2. If you have move than include/, src/, test/, example/, examples/,
+# 2. If you have more than include/, src/, test/, example/, examples/,
 #    benchmark/ or tools/ directories, set the environment variable DEPINST.
 #    For example if your build uses code in "bench/" and "fog/" directories:
 #      - DEPINST: --include bench --include fog
@@ -47,69 +47,69 @@ environment:
   matrix:
     - FLAVOR: Visual Studio 2017 C++2a Strict
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      TOOLSET: msvc-14.1
       B2_ADDRESS_MODEL: address-model=64
-      CXXFLAGS: cxxflags=-permissive-
-      CXXSTD: latest # 2a
+      B2_CXXFLAGS: cxxflags=-permissive-
+      B2_CXXSTD: latest # 2a
+      B2_TOOLSET: msvc-14.1
 
     - FLAVOR: Visual Studio 2017 C++17
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      TOOLSET: msvc-14.1
       B2_ADDRESS_MODEL: address-model=64
-      CXXSTD: 17
+      B2_CXXSTD: 17
+      B2_TOOLSET: msvc-14.1
 
     - FLAVOR: Visual Studio 2017 C++14 (Default)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      TOOLSET: msvc-14.1
       B2_ADDRESS_MODEL: address-model=64,32
+      B2_TOOLSET: msvc-14.1
 
     - FLAVOR: Visual Studio 2015 C++14 (Default)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      TOOLSET: msvc-14.0
       B2_ADDRESS_MODEL: address-model=64,32
+      B2_TOOLSET: msvc-14.0
 
     - FLAVOR: Visual Studio 2010, 2012, 2013
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      TOOLSET: msvc-10.0,msvc-11.0,msvc-12.0
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      B2_TOOLSET: msvc-10.0,msvc-11.0,msvc-12.0
 
     - FLAVOR: cygwin (32-bit)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       ADDPATH: C:\cygwin\bin;
       B2_ADDRESS_MODEL: address-model=32
-      CXXSTD: 03,11
+      B2_CXXSTD: 03,11
       # https://github.com/boostorg/test/issues/144
-      DEFINES: define=_POSIX_C_SOURCE=200112L
-      THREADING: threadapi=pthread
-      TOOLSET: gcc
+      B2_DEFINES: define=_POSIX_C_SOURCE=200112L
+      B2_THREADING: threadapi=pthread
+      B2_TOOLSET: gcc
 
     - FLAVOR: cygwin (64-bit)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       ADDPATH: C:\cygwin64\bin;
       B2_ADDRESS_MODEL: address-model=64
-      CXXSTD: 11,17
+      B2_CXXSTD: 11,17
       # https://github.com/boostorg/test/issues/144
-      DEFINES: define=_POSIX_C_SOURCE=200112L define=__USE_ISOC99
-      THREADING: threadapi=pthread
-      TOOLSET: gcc
+      B2_DEFINES: define=_POSIX_C_SOURCE=200112L define=__USE_ISOC99
+      B2_THREADING: threadapi=pthread
+      B2_TOOLSET: gcc
 
     - FLAVOR: mingw32
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       ARCH: i686
       B2_ADDRESS_MODEL: address-model=32
-      CXXSTD: 03,11
+      B2_CXXSTD: 03,11
       SCRIPT: ci\appveyor\mingw.bat
 
     - FLAVOR: mingw64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       ARCH: x86_64
       B2_ADDRESS_MODEL: address-model=64
-      CXXSTD: 11,17
-      DEFINES: define=__USE_ISOC99
+      B2_CXXSTD: 11,17
+      B2_DEFINES: define=__USE_ISOC99
       SCRIPT: ci\appveyor\mingw.bat
 
 install:
   - set SELF=%APPVEYOR_PROJECT_NAME:-=_%
-  - git clone https://github.com/jeking3/boost-ci.git C:\boost-ci
+  - git clone https://github.com/boostorg/boost-ci.git C:\boost-ci
   - xcopy /s /e /q /i C:\boost-ci\ci .\ci
   - ci\appveyor\install.bat
 
@@ -118,9 +118,9 @@ build: off
 test_script:
   - set SELF=%APPVEYOR_PROJECT_NAME:-=_%
   - PATH=%ADDPATH%%PATH%
-  # The definition of TOOLCXX omits CXXSTD= if it was not defined above
-  - IF NOT DEFINED CXXSTD (SET TOOLCXX=toolset=%TOOLSET%) ELSE (SET TOOLCXX=toolset=%TOOLSET% cxxstd=%CXXSTD%)
+  # The definition of B2_TOOLCXX omits B2_CXXSTD= if it was not defined above
+  - IF NOT DEFINED B2_CXXSTD (SET B2_TOOLCXX=toolset=%B2_TOOLSET%) ELSE (SET B2_TOOLCXX=toolset=%B2_TOOLSET% cxxstd=%B2_CXXSTD%)
   # Echo the complete build command to the build log
-  - IF NOT DEFINED SCRIPT                         (ECHO b2 libs/%SELF:\=/% %TOOLCXX% %CXXFLAGS% %DEFINES% %THREADING% %B2_ADDRESS_MODEL% %B2_LINK% %B2_THREADING% %B2_VARIANT% -j3)
+  - IF NOT DEFINED SCRIPT                         (ECHO b2 libs/%SELF:\=/% %B2_TOOLCXX% %B2_CXXFLAGS% %B2_DEFINES% %B2_THREADING% %B2_ADDRESS_MODEL% %B2_LINK% %B2_THREADING% %B2_VARIANT% -j3)
   # Now go build...
-  - IF DEFINED SCRIPT (call libs\%SELF%\%SCRIPT%) ELSE (b2 libs/%SELF:\=/% %TOOLCXX% %CXXFLAGS% %DEFINES% %THREADING% %B2_ADDRESS_MODEL% %B2_LINK% %B2_THREADING% %B2_VARIANT% -j3)
+  - IF DEFINED SCRIPT (call libs\%SELF%\%SCRIPT%) ELSE (b2 libs/%SELF:\=/% %B2_TOOLCXX% %B2_CXXFLAGS% %B2_DEFINES% %B2_THREADING% %B2_ADDRESS_MODEL% %B2_LINK% %B2_THREADING% %B2_VARIANT% -j3)


### PR DESCRIPTION
Updated Travis CI to use xenial instead of trusty and added B2_ prefix to most of the .travis.yml variables.  The Boost-CI project was updated in a way to make it compatible with the old non-B2_ prefixed items.