### PR TITLE
Fix arbitrary precision rationals with negative denominator

### DIFF
--- a/include/boost/rational.hpp
+++ b/include/boost/rational.hpp
@@ -902,7 +902,7 @@ BOOST_CXX14_CONSTEXPR void rational<IntType>::normalize()
     num /= g;
     den /= g;
 
-    if (den < -(std::numeric_limits<IntType>::max)()) {
+    if (std::numeric_limits<IntType>::is_bounded && den < -(std::numeric_limits<IntType>::max)()) {
         BOOST_THROW_EXCEPTION(bad_rational("bad rational: non-zero singular denominator"));
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ set(BOOST_TEST_LINK_LIBRARIES Boost::rational)
 
 boost_test(TYPE run SOURCES rational_example.cpp)
 boost_test(TYPE run SOURCES rational_test.cpp LINK_LIBRARIES Boost::unit_test_framework)
+boost_test(TYPE run SOURCES multiprecision_test.cpp LINK_LIBRARIES Boost::unit_test_framework Boost::multiprecision COMPILE_FEATURES cxx_std_14)
 boost_test(TYPE run SOURCES constexpr_test.cpp COMPILE_FEATURES cxx_constexpr)
 
 boost_test(TYPE compile-fail SOURCES expected_fail_01.cpp)

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,7 +1,8 @@
 #~ Copyright Rene Rivera 2008
+#~ Copyright (C) 2025 James E. King III
 #~ Distributed under the Boost Software License, Version 1.0.
 #~ (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-
+ 
 import testing ;
 import-search /boost/config/checks ;
 import config : requires ;
@@ -12,6 +13,10 @@ test-suite rational
     :   [ run rational_example.cpp ]
         [ run rational_test.cpp
             /boost/test//boost_unit_test_framework/<link>static ]
+        [ run multiprecision_test.cpp
+            /boost/multiprecision//boost_multiprecision
+            /boost/test//boost_unit_test_framework/<link>static
+            : : : [ requires cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx14_variable_templates cxx14_constexpr ] ]
         [ run constexpr_test.cpp : : : [ requires cxx11_constexpr ] ]
         [ compile-fail expected_fail_01.cpp ]
         [ compile-fail expected_fail_02.cpp ]

--- a/test/multiprecision_test.cpp
+++ b/test/multiprecision_test.cpp
@@ -1,0 +1,21 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright (C) 2025 James E. King III. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_TEST_MAIN  "Boost::Rational multiprecision unit tests"
+
+#include <boost/multiprecision/cpp_int.hpp>
+#include <boost/rational.hpp>
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( issue_27_test )
+{
+    using namespace boost::multiprecision;
+
+    // Verify that the check to ensure that the denominator is positive works
+    // with an arbitrary precision rational.
+    cpp_rational uut(1, -2);
+    BOOST_CHECK_EQUAL(numerator(uut), -1);
+    BOOST_CHECK_EQUAL(denominator(uut), 2);
+}


### PR DESCRIPTION
This fixes https://github.com/boostorg/rational/issues/27.