### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ target_link_libraries(boost_rational
     Boost::config
     Boost::core
     Boost::integer
-    Boost::static_assert
     Boost::throw_exception
     Boost::type_traits
     Boost::utility

--- a/build.jam
+++ b/build.jam
@@ -10,7 +10,6 @@ constant boost_dependencies :
     /boost/config//boost_config
     /boost/core//boost_core
     /boost/integer//boost_integer
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/type_traits//boost_type_traits
     /boost/utility//boost_utility ;


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.